### PR TITLE
Depend on Bash and make portable

### DIFF
--- a/libutils/createconfiguregpr.sh
+++ b/libutils/createconfiguregpr.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Create "configure.gpr" GNATMAKE project file.

--- a/libutils/creategnatadc.sh
+++ b/libutils/creategnatadc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Create "gnat.adc" file.

--- a/libutils/createsymlink.sh
+++ b/libutils/createsymlink.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Create a filesystem symbolic/soft link.

--- a/libutils/processcfg.sh
+++ b/libutils/processcfg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Process a configuration template file.


### PR DESCRIPTION
As mentioned in my email, here is the small set of patches that I had to apply for SweetAda to run on Debian/aarch64.

These scripts depend on `/bin/sh`. This is not always `bash`. For example in Debian, the system Shell is `dash`, which is only POSIX compliant.

`dash` does not understand `set -o posix` as that is not part of POSIX (oh the irony). On top of that, there are features used in these scripts that make them not POSIX compliant, for example, the use of arrays, which are not part of POSIX.

More non-POSIX issues can be seen by copying the `.sh` files into [ShellCheck](https://www.shellcheck.net/). It is a really good linter for issues and potential problems. It gives a more in depth view on the non-POSIX points of the scripts.

For the reasons above, I had to patch `bash` to be used in the scripts. I used `/usr/bin/env` as that is a portable *NIX way of calling programs.

Feedback is welcome. Best regards,
Fer