### PR TITLE
Initial support for the NEORV32 cpu on the ULX3S FPGA synthesized with Litex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Emacs temporary files
+*~
+
+# All compilation files
+*.o
+*.ali
+*.elf
+*.elf*
+*.bin
+
+# All compiled directories
+/obj
+/lib
+/rts/sfp
+/rts/zfp
+
+# Intermediate/Compiled files
+/application/application.adb
+/application/application.ads
+
+gnat.adc
+gnatbind_alis.lst
+gnatbind_elab.lst
+gnatbind_objs.lst
+kernel.cfg
+kernel.lst
+kernel.map
+kernel.src.lst
+libgnarl.lst
+libgnat.lst
+
+configure.gpr
+core/gcc_defines.ads

--- a/platforms/NEORV32/platform-ULX3S-Litex/bsp.adb
+++ b/platforms/NEORV32/platform-ULX3S-Litex/bsp.adb
@@ -1,0 +1,130 @@
+-----------------------------------------------------------------------------------------------------------------------
+--                                                     SweetAda                                                      --
+-----------------------------------------------------------------------------------------------------------------------
+-- __HDS__                                                                                                           --
+-- __FLN__ bsp.adb                                                                                                   --
+-- __DSC__                                                                                                           --
+-- __HSH__ e69de29bb2d1d6434b8b29ae775ad8c2e48c5391                                                                  --
+-- __HDE__                                                                                                           --
+-----------------------------------------------------------------------------------------------------------------------
+-- Copyright (C) 2020-2024 Gabriele Galeotti                                                                         --
+--                                                                                                                   --
+-- SweetAda web page: http://sweetada.org                                                                            --
+-- contact address: gabriele.galeotti@sweetada.org                                                                   --
+-- This work is licensed under the terms of the MIT License.                                                         --
+-- Please consult the LICENSE.txt file located in the top-level directory.                                           --
+-----------------------------------------------------------------------------------------------------------------------
+
+with Definitions;
+with Bits;
+with RISCV;
+with MTIME;
+with NEORV32;
+with Exceptions;
+with Console;
+
+package body BSP
+   is
+
+   --========================================================================--
+   --                                                                        --
+   --                                                                        --
+   --                           Local declarations                           --
+   --                                                                        --
+   --                                                                        --
+   --========================================================================--
+
+   use Interfaces;
+   use Definitions;
+   use Bits;
+   use RISCV;
+   use MTIME;
+   use NEORV32;
+
+   --========================================================================--
+   --                                                                        --
+   --                                                                        --
+   --                           Package subprograms                          --
+   --                                                                        --
+   --                                                                        --
+   --========================================================================--
+
+   ----------------------------------------------------------------------------
+   -- Console wrappers
+   ----------------------------------------------------------------------------
+
+   procedure Console_Putchar
+      (C : in Character)
+      is
+   begin
+      -- wait for transmitter available
+      loop
+         exit when not UART0.CTRL.UART_CTRL_TX_FULL;
+      end loop;
+      UART0.DATA.UART_DATA_RTX := To_U8 (C);
+   end Console_Putchar;
+
+   procedure Console_Getchar
+      (C : out Character)
+      is
+      Data : Unsigned_8;
+   begin
+      -- wait for receiver available
+      loop
+         exit when UART0.CTRL.UART_CTRL_RX_NEMPTY;
+      end loop;
+      Data := UART0.DATA.UART_DATA_RTX;
+      C := To_Ch (Data);
+   end Console_Getchar;
+
+   ----------------------------------------------------------------------------
+   -- Setup
+   ----------------------------------------------------------------------------
+   procedure Setup
+      is
+   begin
+      -- UART0 ----------------------------------------------------------------
+      -- serial port wiring:
+      -- GND = GPIO-30
+      -- RXD = GPIO-33
+      -- TXD = GPIO-34
+      -- 19200 baud @ clk_i = 90 MHz
+      -- Baud rate = (fmain[Hz] / clock_prescaler) / (baud_div + 1)
+      UART0.CTRL := (
+         UART_CTRL_EN            => True,
+         UART_CTRL_SIM_MODE      => False,
+         UART_CTRL_HWFC_EN       => False,
+         UART_CTRL_PRSC          => UART_CTRL_PRSC_DIV8,
+         UART_CTRL_BAUD          => Bits_10 (50 * MHz1 / (8 * 115_200) - 1),
+         UART_CTRL_RX_NEMPTY     => False,
+         UART_CTRL_RX_HALF       => False,
+         UART_CTRL_RX_FULL       => False,
+         UART_CTRL_TX_EMPTY      => False,
+         UART_CTRL_TX_NHALF      => False,
+         UART_CTRL_TX_FULL       => False,
+         UART_CTRL_IRQ_RX_NEMPTY => False,
+         UART_CTRL_IRQ_RX_HALF   => False,
+         UART_CTRL_IRQ_RX_FULL   => False,
+         UART_CTRL_IRQ_TX_EMPTY  => False,
+         UART_CTRL_IRQ_TX_NHALF  => False,
+         UART_CTRL_RX_OVER       => False,
+         UART_CTRL_TX_BUSY       => False,
+         others                  => <>
+         );
+      -- Console --------------------------------------------------------------
+      Console.Console_Descriptor.Write := Console_Putchar'Access;
+      Console.Console_Descriptor.Read  := Console_Getchar'Access;
+      Console.Print (ANSI_CLS & ANSI_CUPHOME & VT100_LINEWRAP);
+      -------------------------------------------------------------------------
+      Console.Print ("NEORV32 (ULX3S)", NL => True);
+      -------------------------------------------------------------------------
+      Exceptions.Init;
+      -------------------------------------------------------------------------
+      Timer_Value := mtime_Read + Timer_Constant;
+      mtimecmp_Write (Timer_Value);
+      mie_Set_Interrupt ((MTIE => True, others => <>));
+      Irq_Enable;
+      -------------------------------------------------------------------------
+   end Setup;
+
+end BSP;

--- a/platforms/NEORV32/platform-ULX3S-Litex/bsp.ads
+++ b/platforms/NEORV32/platform-ULX3S-Litex/bsp.ads
@@ -1,0 +1,46 @@
+-----------------------------------------------------------------------------------------------------------------------
+--                                                     SweetAda                                                      --
+-----------------------------------------------------------------------------------------------------------------------
+-- __HDS__                                                                                                           --
+-- __FLN__ bsp.ads                                                                                                   --
+-- __DSC__                                                                                                           --
+-- __HSH__ e69de29bb2d1d6434b8b29ae775ad8c2e48c5391                                                                  --
+-- __HDE__                                                                                                           --
+-----------------------------------------------------------------------------------------------------------------------
+-- Copyright (C) 2020-2024 Gabriele Galeotti                                                                         --
+--                                                                                                                   --
+-- SweetAda web page: http://sweetada.org                                                                            --
+-- contact address: gabriele.galeotti@sweetada.org                                                                   --
+-- This work is licensed under the terms of the MIT License.                                                         --
+-- Please consult the LICENSE.txt file located in the top-level directory.                                           --
+-----------------------------------------------------------------------------------------------------------------------
+
+with Interfaces;
+
+package BSP
+   is
+
+   --========================================================================--
+   --                                                                        --
+   --                                                                        --
+   --                               Public part                              --
+   --                                                                        --
+   --                                                                        --
+   --========================================================================--
+
+   Tick_Count : aliased Interfaces.Unsigned_32 := 0
+      with Atomic        => True,
+           Export        => True,
+           Convention    => Asm,
+           External_Name => "tick_count";
+
+   Timer_Constant : constant := 16#0200_0000#;
+   Timer_Value    : Interfaces.Unsigned_64;
+
+   procedure Console_Putchar
+      (C : in Character);
+   procedure Console_Getchar
+      (C : out Character);
+   procedure Setup;
+
+end BSP;

--- a/platforms/NEORV32/platform-ULX3S-Litex/configuration.in
+++ b/platforms/NEORV32/platform-ULX3S-Litex/configuration.in
@@ -1,0 +1,70 @@
+
+#
+# NEORV32
+#
+# RISC-V RV32IMC
+#
+
+################################################################################
+# Basic system parameters.                                                     #
+#                                                                              #
+################################################################################
+
+RTS        := sfp
+PROFILE    := sfp
+USE_LIBADA := Y
+
+USE_APPLICATION := test-NEORV32
+
+################################################################################
+# CPU.                                                                         #
+#                                                                              #
+################################################################################
+
+CPU       := RISC-V
+CPU_MODEL := RV32
+
+################################################################################
+# Build system parameters.                                                     #
+#                                                                              #
+################################################################################
+
+GCC_SWITCHES_PLATFORM     := -march=rv32i2p0_mc -mabi=ilp32
+LD_SWITCHES_PLATFORM      += -m elf32lriscv
+LD_SWITCHES_PLATFORM      += --defsym _riscv_mtime_mmap=0xFFFFFF90
+LD_SWITCHES_PLATFORM      += --defsym _riscv_mtimecmp_mmap=0xFFFFFF98
+OBJDUMP_SWITCHES_PLATFORM :=
+OBJCOPY_SWITCHES_PLATFORM :=
+POSTBUILD_ROMFILE         :=
+
+OPTIMIZATION_LEVEL        := 2
+
+CONFIGURE_FILES_PLATFORM := configure.ads configure.h
+LOWLEVEL_FILES_PLATFORM  := startup.S llkernel.S
+
+################################################################################
+# User parameters.                                                             #
+#                                                                              #
+################################################################################
+
+################################################################################
+# Run/debug interface.                                                         #
+#                                                                              #
+################################################################################
+
+#
+# NEORV32_HOME is the top-level directory created when NEORV32 is checked out
+# from the repository. This implementation refers to:
+# https://github.com/emb4fun/neorv32-examples
+#
+# As a prerequisite, go into the "<NEORV32_HOME>/sw/example/hello_world"
+# directory an do a "make ../../../sw/image_gen/image_gen" to create the
+# executable that will be used in translating the SweetAda binary image.
+#
+
+SESSION_START_COMMAND :=
+SESSION_END_COMMAND   :=
+
+RUN_COMMAND   := "$(SWEETADA_PATH)"/$(PLATFORM_DIRECTORY)/neorv32.sh
+DEBUG_COMMAND :=
+

--- a/platforms/NEORV32/platform-ULX3S-Litex/linker.lds
+++ b/platforms/NEORV32/platform-ULX3S-Litex/linker.lds
@@ -1,0 +1,104 @@
+
+ENTRY(_start)
+
+MEMORY
+{
+        ROM : ORIGIN = 0x00000000, LENGTH = 64k
+        /*  Default Litex boot sector */
+        RAM : ORIGIN = 0x40000000, LENGTH = 32k
+}
+
+SECTIONS
+{
+        /**********************************************************************
+         *                                                                    *
+         **********************************************************************/
+        .text :
+        {
+                _stext = .;
+                *(.startup)
+                *(.text)
+                *(.text.*)
+                *(.vectors)
+                *(.rodata)
+                *(.rodata.*)
+                *(.srodata)
+                *(.srodata.*)
+                . = ALIGN(0x10);
+                _etext = .;
+        } > ROM
+        /**********************************************************************
+         *                                                                    *
+         **********************************************************************/
+        .data :
+        {
+                _sdata = .;
+                *(.data)
+                *(.data.*)
+                *(.sdata)
+                *(.sdata.*)
+                *(.sdata2)
+                *(.sdata2.*)
+                . = ALIGN(0x4);
+                _edata = .;
+                _gp = _edata + 0x800;
+        } > RAM AT > ROM
+        /**********************************************************************
+         *                                                                    *
+         **********************************************************************/
+        .bss ADDR(.data) + SIZEOF(.data) (NOLOAD) :
+        {
+                _sbss = .;
+                *(.bss)
+                *(.bss.*)
+                *(.sbss)
+                *(.sbss.*)
+                *(COMMON)
+                _ebss = .;
+        } > RAM
+        /**********************************************************************
+         *                                                                    *
+         **********************************************************************/
+        /* DWARF 1 */
+        .debug             0 : { *(.debug) }
+        .line              0 : { *(.line) }
+        /* GNU DWARF 1 extensions */
+        .debug_srcinfo     0 : { *(.debug_srcinfo) }
+        .debug_sfnames     0 : { *(.debug_sfnames) }
+        /* DWARF 1.1 and DWARF 2 */
+        .debug_aranges     0 : { *(.debug_aranges) }
+        .debug_pubnames    0 : { *(.debug_pubnames) }
+        /* DWARF 2 */
+        .debug_info        0 : { *(.debug_info .gnu.linkonce.wi.*) }
+        .debug_abbrev      0 : { *(.debug_abbrev) }
+        .debug_line        0 : { *(.debug_line .debug_line.* .debug_line_end ) }
+        .debug_frame       0 : { *(.debug_frame) }
+        .debug_str         0 : { *(.debug_str) }
+        .debug_loc         0 : { *(.debug_loc) }
+        .debug_macinfo     0 : { *(.debug_macinfo) }
+        /* SGI/MIPS DWARF 2 extensions */
+        .debug_weaknames   0 : { *(.debug_weaknames) }
+        .debug_funcnames   0 : { *(.debug_funcnames) }
+        .debug_typenames   0 : { *(.debug_typenames) }
+        .debug_varnames    0 : { *(.debug_varnames) }
+        /* DWARF 3 */
+        .debug_pubtypes    0 : { *(.debug_pubtypes) }
+        .debug_ranges      0 : { *(.debug_ranges) }
+        /* DWARF 5 */
+        .debug_addr        0 : { *(.debug_addr) }
+        .debug_line_str    0 : { *(.debug_line_str) }
+        .debug_loclists    0 : { *(.debug_loclists) }
+        .debug_macro       0 : { *(.debug_macro) }
+        .debug_names       0 : { *(.debug_names) }
+        .debug_rnglists    0 : { *(.debug_rnglists) }
+        .debug_str_offsets 0 : { *(.debug_str_offsets) }
+        .debug_sup         0 : { *(.debug_sup) }
+        /**********************************************************************
+         *                                                                    *
+         **********************************************************************/
+        /DISCARD/ :
+        {
+                *(*)
+        }
+}
+

--- a/platforms/NEORV32/platform-ULX3S-Litex/neorv32.adb
+++ b/platforms/NEORV32/platform-ULX3S-Litex/neorv32.adb
@@ -1,0 +1,80 @@
+-----------------------------------------------------------------------------------------------------------------------
+--                                                     SweetAda                                                      --
+-----------------------------------------------------------------------------------------------------------------------
+-- __HDS__                                                                                                           --
+-- __FLN__ neorv32.adb                                                                                               --
+-- __DSC__                                                                                                           --
+-- __HSH__ e69de29bb2d1d6434b8b29ae775ad8c2e48c5391                                                                  --
+-- __HDE__                                                                                                           --
+-----------------------------------------------------------------------------------------------------------------------
+-- Copyright (C) 2020-2024 Gabriele Galeotti                                                                         --
+--                                                                                                                   --
+-- SweetAda web page: http://sweetada.org                                                                            --
+-- contact address: gabriele.galeotti@sweetada.org                                                                   --
+-- This work is licensed under the terms of the MIT License.                                                         --
+-- Please consult the LICENSE.txt file located in the top-level directory.                                           --
+-----------------------------------------------------------------------------------------------------------------------
+
+package body NEORV32
+   is
+
+   --========================================================================--
+   --                                                                        --
+   --                                                                        --
+   --                           Package subprograms                          --
+   --                                                                        --
+   --                                                                        --
+   --========================================================================--
+
+   -- XIRQ module
+
+   procedure EIE_Read
+      (XIRQ_CH : out Bits_32)
+      is
+   begin
+      XIRQ_CH := EIE;
+   end EIE_Read;
+
+   procedure EIE_Enable
+      (XIRQ_CH : in Bits_32)
+      is
+   begin
+      EIE := @ or XIRQ_CH;
+   end EIE_Enable;
+
+   procedure EIE_Disable
+      (XIRQ_CH : in Bits_32)
+      is
+   begin
+      EIE := @ and not XIRQ_CH;
+   end EIE_Disable;
+
+   procedure EIP_Read
+      (XIRQ_CH : out Bits_32)
+      is
+   begin
+      XIRQ_CH := EIP;
+   end EIP_Read;
+
+   procedure EIP_Clear
+      (XIRQ_CH : in Bits_32)
+      is
+   begin
+      EIP := not XIRQ_CH;
+   end EIP_Clear;
+
+   procedure ESC_Read
+      (XIRQ_CH : out Bits_32)
+      is
+   begin
+      XIRQ_CH := ESC;
+   end ESC_Read;
+
+   procedure ESC_Ack
+      (XIRQ_CH : in Bits_32)
+      is
+   begin
+      ESC := XIRQ_CH;
+   end ESC_Ack;
+
+end NEORV32;

--- a/platforms/NEORV32/platform-ULX3S-Litex/neorv32.ads
+++ b/platforms/NEORV32/platform-ULX3S-Litex/neorv32.ads
@@ -1,0 +1,354 @@
+-----------------------------------------------------------------------------------------------------------------------
+--                                                     SweetAda                                                      --
+-----------------------------------------------------------------------------------------------------------------------
+-- __HDS__                                                                                                           --
+-- __FLN__ neorv32.ads                                                                                               --
+-- __DSC__                                                                                                           --
+-- __HSH__ e69de29bb2d1d6434b8b29ae775ad8c2e48c5391                                                                  --
+-- __HDE__                                                                                                           --
+-----------------------------------------------------------------------------------------------------------------------
+-- Copyright (C) 2020-2024 Gabriele Galeotti                                                                         --
+--                                                                                                                   --
+-- SweetAda web page: http://sweetada.org                                                                            --
+-- contact address: gabriele.galeotti@sweetada.org                                                                   --
+-- This work is licensed under the terms of the MIT License.                                                         --
+-- Please consult the LICENSE.txt file located in the top-level directory.                                           --
+-----------------------------------------------------------------------------------------------------------------------
+
+with System;
+with Interfaces;
+with Bits;
+
+package NEORV32
+   with Preelaborate => True
+   is
+
+   --========================================================================--
+   --                                                                        --
+   --                                                                        --
+   --                               Public part                              --
+   --                                                                        --
+   --                                                                        --
+   --========================================================================--
+
+   use System;
+   use Interfaces;
+   use Bits;
+
+   -- 2.7.9. General Purpose Input and Output Port (GPIO)
+
+   type GPIO_Type is record
+      INPUT_LO  : Bitmap_32 with Volatile_Full_Access => True;
+      INPUT_HI  : Bitmap_32 with Volatile_Full_Access => True;
+      OUTPUT_LO : Bitmap_32 with Volatile_Full_Access => True;
+      OUTPUT_HI : Bitmap_32 with Volatile_Full_Access => True;
+   end record
+      with Size => 4 * 32;
+   for GPIO_Type use record
+      INPUT_LO  at 16#0# range 0 .. 31;
+      INPUT_HI  at 16#4# range 0 .. 31;
+      OUTPUT_LO at 16#8# range 0 .. 31;
+      OUTPUT_HI at 16#C# range 0 .. 31;
+   end record;
+
+   GPIO_ADDRESS : constant := 16#FFFF_FFC0#;
+
+   GPIO : aliased GPIO_Type
+      with Address    => System'To_Address (GPIO_ADDRESS),
+           Volatile   => True,
+           Import     => True,
+           Convention => Ada;
+
+   -- 2.7.10. Cyclic Redundancy Check (CRC)
+
+   -- CRC_MODE_CRC8  : constant := 2#00#; -- CRC8
+   -- CRC_MODE_CRC16 : constant := 2#01#; -- CRC16
+   -- CRC_MODE_CRC32 : constant := 2#10#; -- CRC32
+
+   -- type CRC_CTRL_Type is record
+   --    MODE     : Bits_2;       -- CRC mode select
+   --    Reserved : Bits_30 := 0;
+   -- end record
+   --    with Bit_Order => Low_Order_First,
+   --         Size      => 32;
+   -- for CRC_CTRL_Type use record
+   --    MODE     at 0 range 0 ..  1;
+   --    Reserved at 0 range 2 .. 31;
+   -- end record;
+
+   -- type CRC_DATA_Type is record
+   --    DATA     : Unsigned_8;   -- data input
+   --    Reserved : Bits_24 := 0;
+   -- end record
+   --    with Bit_Order => Low_Order_First,
+   --         Size      => 32;
+   -- for CRC_DATA_Type use record
+   --    DATA     at 0 range 0 ..  7;
+   --    Reserved at 0 range 8 .. 31;
+   -- end record;
+
+   -- type CRC_Type is record
+   --    CTRL : CRC_CTRL_Type with Volatile_Full_Access => True;
+   --    POLY : Unsigned_32   with Volatile_Full_Access => True;
+   --    DATA : CRC_DATA_Type with Volatile_Full_Access => True;
+   --    SREG : Unsigned_32   with Volatile_Full_Access => True;
+   -- end record
+   --    with Size => 4 * 32;
+   -- for CRC_Type use record
+   --    CTRL at 16#0# range 0 .. 31;
+   --    POLY at 16#4# range 0 .. 31;
+   --    DATA at 16#8# range 0 .. 31;
+   --    SREG at 16#C# range 0 .. 31;
+   -- end record;
+
+   -- CRC_BASEADDRESS : constant := 16#FFFF_EE00#;
+
+   -- CRC : aliased CRC_Type
+   --    with Address    => System'To_Address (CRC_BASEADDRESS),
+   --         Volatile   => True,
+   --         Import     => True,
+   --         Convention => Ada;
+
+   -- 2.7.11. Watchdog Timer (WDT)
+
+   WDT_CTRL_RCAUSE_EXTRST : constant := 2#00#; -- external reset
+   WDT_CTRL_RCAUSE_OCDRST : constant := 2#01#; -- ocd-reset
+   WDT_CTRL_RCAUSE_WDTRST : constant := 2#10#; -- watchdog reset
+
+   type WDT_CTRL_Type is record
+      WDT_CTRL_EN      : Boolean;     -- watchdog enable
+      WDT_CTRL_LOCK    : Boolean;     -- lock configuration
+      WDT_CTRL_DBEN    : Boolean;     -- set to allow WDT to continue operation even when CPU is in debug mode
+      WDT_CTRL_SEN     : Boolean;     -- set to allow WDT to continue operation even when CPU is in sleep mode
+      WDT_CTRL_STRICT  : Boolean;     -- set to enable strict mode
+      WDT_CTRL_RCAUSE  : Bits_2;      -- cause of last system reset
+      Reserved         : Bits_1 := 0;
+      WDT_CTRL_TIMEOUT : Bits_24;     -- 24-bit watchdog timeout value
+   end record
+      with Bit_Order => Low_Order_First,
+           Size      => 32;
+   for WDT_CTRL_Type use record
+      WDT_CTRL_EN      at 0 range 0 ..  0;
+      WDT_CTRL_LOCK    at 0 range 1 ..  1;
+      WDT_CTRL_DBEN    at 0 range 2 ..  2;
+      WDT_CTRL_SEN     at 0 range 3 ..  3;
+      WDT_CTRL_STRICT  at 0 range 4 ..  4;
+      WDT_CTRL_RCAUSE  at 0 range 5 ..  6;
+      Reserved         at 0 range 7 ..  7;
+      WDT_CTRL_TIMEOUT at 0 range 8 .. 31;
+   end record;
+
+   WDT_RESET_PASSWORD : constant := 16#709D_1AB3#;
+
+   type WDT_Type is record
+      CTRL  : WDT_CTRL_Type with Volatile_Full_Access => True;
+      RESET : Unsigned_32   with Volatile_Full_Access => True;
+   end record
+      with Size => 2 * 32;
+   for WDT_Type use record
+      CTRL  at 0 range 0 .. 31;
+      RESET at 4 range 0 .. 31;
+   end record;
+
+   WDT_ADDRESS : constant := 16#FFFF_FFBC#;
+
+   WDT : aliased WDT_Type
+      with Address    => System'To_Address (WDT_ADDRESS),
+           Volatile   => True,
+           Import     => True,
+           Convention => Ada;
+
+   -- 2.7.13. Primary Universal Asynchronous Receiver and Transmitter (UART0)
+   -- 2.7.14. Secondary Universal Asynchronous Receiver and Transmitter (UART1)
+
+   UART_CTRL_PRSC_DIV2    : constant := 2#000#; -- Resulting clock_prescaler = 2
+   UART_CTRL_PRSC_DIV4    : constant := 2#001#; -- Resulting clock_prescaler = 4
+   UART_CTRL_PRSC_DIV8    : constant := 2#010#; -- Resulting clock_prescaler = 8
+   UART_CTRL_PRSC_DIV64   : constant := 2#011#; -- Resulting clock_prescaler = 64
+   UART_CTRL_PRSC_DIV128  : constant := 2#100#; -- Resulting clock_prescaler = 128
+   UART_CTRL_PRSC_DIV1024 : constant := 2#101#; -- Resulting clock_prescaler = 1024
+   UART_CTRL_PRSC_DIV2048 : constant := 2#110#; -- Resulting clock_prescaler = 2048
+   UART_CTRL_PRSC_DIV4096 : constant := 2#111#; -- Resulting clock_prescaler = 4096
+
+   type UART_CTRL_Type is record
+      UART_CTRL_EN            : Boolean;     -- UART global enable
+      UART_CTRL_SIM_MODE      : Boolean;     -- Simulation output override enable
+      UART_CTRL_HWFC_EN       : Boolean;     -- Enable RTS/CTS hardware flow-control
+      UART_CTRL_PRSC          : Bits_3;      -- clock prescaler select
+      UART_CTRL_BAUD          : Bits_10;     -- BAUD rate divisor
+      UART_CTRL_RX_NEMPTY     : Boolean;     -- RX FIFO not empty
+      UART_CTRL_RX_HALF       : Boolean;     -- RX FIFO at least half-full
+      UART_CTRL_RX_FULL       : Boolean;     -- RX FIFO full
+      UART_CTRL_TX_EMPTY      : Boolean;     -- TX FIFO empty
+      UART_CTRL_TX_NHALF      : Boolean;     -- TX FIFO not at least half-full
+      UART_CTRL_TX_FULL       : Boolean;     -- TX FIFO full
+      UART_CTRL_IRQ_RX_NEMPTY : Boolean;     -- Fire IRQ if RX FIFO not empty
+      UART_CTRL_IRQ_RX_HALF   : Boolean;     -- Fire IRQ if RX FIFO at least half-full
+      UART_CTRL_IRQ_RX_FULL   : Boolean;     -- Fire IRQ if RX FIFO full
+      UART_CTRL_IRQ_TX_EMPTY  : Boolean;     -- Fire IRQ if TX FIFO empty
+      UART_CTRL_IRQ_TX_NHALF  : Boolean;     -- Fire IRQ if TX FIFO not at least half-full
+      Reserved                : Bits_3 := 0;
+      UART_CTRL_RX_OVER       : Boolean;     -- RX FIFO overflow
+      UART_CTRL_TX_BUSY       : Boolean;     -- Transmitter busy or TX FIFO not empty
+   end record
+      with Bit_Order => Low_Order_First,
+           Size      => 32;
+   for UART_CTRL_Type use record
+      UART_CTRL_EN            at 0 range  0 ..  0;
+      UART_CTRL_SIM_MODE      at 0 range  1 ..  1;
+      UART_CTRL_HWFC_EN       at 0 range  2 ..  2;
+      UART_CTRL_PRSC          at 0 range  3 ..  5;
+      UART_CTRL_BAUD          at 0 range  6 .. 15;
+      UART_CTRL_RX_NEMPTY     at 0 range 16 .. 16;
+      UART_CTRL_RX_HALF       at 0 range 17 .. 17;
+      UART_CTRL_RX_FULL       at 0 range 18 .. 18;
+      UART_CTRL_TX_EMPTY      at 0 range 19 .. 19;
+      UART_CTRL_TX_NHALF      at 0 range 20 .. 20;
+      UART_CTRL_TX_FULL       at 0 range 21 .. 21;
+      UART_CTRL_IRQ_RX_NEMPTY at 0 range 22 .. 22;
+      UART_CTRL_IRQ_RX_HALF   at 0 range 23 .. 23;
+      UART_CTRL_IRQ_RX_FULL   at 0 range 24 .. 24;
+      UART_CTRL_IRQ_TX_EMPTY  at 0 range 25 .. 25;
+      UART_CTRL_IRQ_TX_NHALF  at 0 range 26 .. 26;
+      Reserved                at 0 range 27 .. 29;
+      UART_CTRL_RX_OVER       at 0 range 30 .. 30;
+      UART_CTRL_TX_BUSY       at 0 range 31 .. 31;
+   end record;
+
+   type UART_DATA_Type is record
+      UART_DATA_RTX          : Unsigned_8;   -- UART receive/transmit data
+      UART_DATA_RX_FIFO_SIZE : Bits_4 := 0;  -- log2(RX FIFO size)
+      UART_DATA_TX_FIFO_SIZE : Bits_4 := 0;  -- log2(TX FIFO size)
+      Reserved               : Bits_16 := 0;
+   end record
+      with Bit_Order => Low_Order_First,
+           Size      => 32;
+   for UART_DATA_Type use record
+      UART_DATA_RTX          at 0 range  0 ..  7;
+      UART_DATA_RX_FIFO_SIZE at 0 range  8 .. 11;
+      UART_DATA_TX_FIFO_SIZE at 0 range 12 .. 15;
+      Reserved               at 0 range 16 .. 31;
+   end record;
+
+   type UART_Type is record
+      CTRL : UART_CTRL_Type with Volatile_Full_Access => True;
+      DATA : UART_DATA_Type with Volatile_Full_Access => True;
+   end record
+      with Size => 2 * 32;
+   for UART_Type use record
+      CTRL at 0 range 0 .. 31;
+      DATA at 4 range 0 .. 31;
+   end record;
+
+   UART0_BASEADDRESS : constant := 16#FFFF_FFA0#;
+
+   UART0 : aliased UART_Type
+      with Address    => System'To_Address (UART0_BASEADDRESS),
+           Volatile   => True,
+           Import     => True,
+           Convention => Ada;
+
+   UART1_BASEADDRESS : constant := 16#FFFF_FFD0#;
+
+   UART1 : aliased UART_Type
+      with Address    => System'To_Address (UART1_BASEADDRESS),
+           Volatile   => True,
+           Import     => True,
+           Convention => Ada;
+
+   -- 2.7.23. External Interrupt Controller (XIRQ)
+
+   XIRQ_NONE : constant := 0;
+   XIRQ_CH0  : constant := 2**0;
+   XIRQ_CH1  : constant := 2**1;
+   XIRQ_CH2  : constant := 2**2;
+   XIRQ_CH3  : constant := 2**3;
+   XIRQ_CH4  : constant := 2**4;
+   XIRQ_CH5  : constant := 2**5;
+   XIRQ_CH6  : constant := 2**6;
+   XIRQ_CH7  : constant := 2**7;
+   XIRQ_CH8  : constant := 2**8;
+   XIRQ_CH9  : constant := 2**9;
+   XIRQ_CH10 : constant := 2**10;
+   XIRQ_CH11 : constant := 2**11;
+   XIRQ_CH12 : constant := 2**12;
+   XIRQ_CH13 : constant := 2**13;
+   XIRQ_CH14 : constant := 2**14;
+   XIRQ_CH15 : constant := 2**15;
+   XIRQ_CH16 : constant := 2**16;
+   XIRQ_CH17 : constant := 2**17;
+   XIRQ_CH18 : constant := 2**18;
+   XIRQ_CH19 : constant := 2**19;
+   XIRQ_CH20 : constant := 2**20;
+   XIRQ_CH21 : constant := 2**21;
+   XIRQ_CH22 : constant := 2**22;
+   XIRQ_CH23 : constant := 2**23;
+   XIRQ_CH24 : constant := 2**24;
+   XIRQ_CH25 : constant := 2**25;
+   XIRQ_CH26 : constant := 2**26;
+   XIRQ_CH27 : constant := 2**27;
+   XIRQ_CH28 : constant := 2**28;
+   XIRQ_CH29 : constant := 2**29;
+   XIRQ_CH30 : constant := 2**30;
+   XIRQ_CH31 : constant := 2**31;
+   XIRQ_ALL  : constant := 16#FFFF_FFFF#;
+
+   -- EIE External interrupt enable register
+
+   EIE_ADDRESS : constant := 16#FFFF_FF80#;
+
+   EIE : aliased Bits_32
+      with Address              => System'To_Address (EIE_ADDRESS),
+           Volatile_Full_Access => True,
+           Import               => True,
+           Convention           => Ada;
+
+   procedure EIE_Read
+      (XIRQ_CH : out Bits_32)
+      with Inline => True;
+
+   procedure EIE_Enable
+      (XIRQ_CH : in Bits_32)
+      with Inline => True;
+
+   procedure EIE_Disable
+      (XIRQ_CH : in Bits_32)
+      with Inline => True;
+
+   -- EIP External interrupt pending register
+
+   EIP_ADDRESS : constant := 16#FFFF_FF84#;
+
+   EIP : aliased Bits_32
+      with Address              => System'To_Address (EIP_ADDRESS),
+           Volatile_Full_Access => True,
+           Import               => True,
+           Convention           => Ada;
+
+   procedure EIP_Read
+      (XIRQ_CH : out Bits_32)
+      with Inline => True;
+
+   procedure EIP_Clear
+      (XIRQ_CH : in Bits_32)
+      with Inline => True;
+
+   -- ESC Interrupt source ID
+
+   ESC_ADDRESS : constant := 16#FFFF_FF88#;
+
+   ESC : aliased Bits_32
+      with Address              => System'To_Address (ESC_ADDRESS),
+           Volatile_Full_Access => True,
+           Import               => True,
+           Convention           => Ada;
+
+   procedure ESC_Read
+      (XIRQ_CH : out Bits_32)
+      with Inline => True;
+
+   procedure ESC_Ack
+      (XIRQ_CH : in Bits_32)
+      with Inline => True;
+
+end NEORV32;

--- a/platforms/NEORV32/platform-ULX3S-Litex/neorv32.sh
+++ b/platforms/NEORV32/platform-ULX3S-Litex/neorv32.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+
+#
+# NEORV32 GHDL front-end script.
+#
+# Copyright (C) 2020-2024 Gabriele Galeotti
+#
+# This work is licensed under the terms of the MIT License.
+# Please consult the LICENSE.txt file located in the top-level directory.
+#
+
+#
+# Arguments:
+# none
+#
+# Environment variables:
+# PATH
+# PLATFORM_DIRECTORY
+# KERNEL_OUTFILE
+# OBJCOPY
+# NEORV32_HOME
+# GHDL_PATH
+#
+
+################################################################################
+# Script initialization.                                                       #
+#                                                                              #
+################################################################################
+
+SCRIPT_FILENAME=$(basename "$0")
+
+################################################################################
+# Main loop.                                                                   #
+#                                                                              #
+################################################################################
+
+# generate a pure binary image out of .text/.rodata/.data sections
+${OBJCOPY}                                     \
+  -j .text -j .rodata -j .data                 \
+  -I elf32-little ${KERNEL_OUTFILE}            \
+  -O binary ${PLATFORM_DIRECTORY}/sweetada.bin
+
+# Upload binary to device using the Litex tools
+# We are assuming that the synthesis was done with Litex
+USB_PORT=/dev/ttyUSB0
+
+litex_term ${USB_PORT} --kernel=${PLATFORM_DIRECTORY}/sweetada.bin
+
+exit 0
+


### PR DESCRIPTION
Hi Gabriele,

I have an initial skeleton for the NEORV32 running on the ULX3S FPGA that was synthesized using Litex. It still does not print to the terminal/UART. I have only adjusted the `configuration.in` file with the extra bits that the setup supports and the `linker.ld` script, with the `RAM` address. I now need to look into the registers and see how they are setup.

I have also added a .gitignore file to the project so that generated files are not added automatically to the tree.

You may want to merge this as is (broken) and I will fix it later, or you can wait for me to have an initial working configuration. Comments are also greatly welcomed. 

Best regards,
Fer